### PR TITLE
nx-goのgeneratorの細かいバグ修正

### DIFF
--- a/packages/nx-go/src/generators/application/generator.ts
+++ b/packages/nx-go/src/generators/application/generator.ts
@@ -67,7 +67,7 @@ export default async function (tree: Tree, options: ApplicationGeneratorSchema) 
   addProjectConfiguration(tree, normalizedOptions.projectName, {
     root: normalizedOptions.projectRoot,
     projectType: 'application',
-    sourceRoot: `${normalizedOptions.projectRoot}/src`,
+    sourceRoot: normalizedOptions.projectRoot,
     targets: {
       lint: {
         executor: '@nrwl/workspace:run-commands',

--- a/packages/nx-go/src/generators/application/generator.ts
+++ b/packages/nx-go/src/generators/application/generator.ts
@@ -86,7 +86,7 @@ export default async function (tree: Tree, options: ApplicationGeneratorSchema) 
       build: {
         executor: '@nrwl/workspace:run-commands',
         options: {
-          command: `go build -o ${offsetFromRoot(normalizedOptions.projectRoot)}/dist/${normalizedOptions.projectRoot} main.go`,
+          command: `go build -o ${offsetFromRoot(normalizedOptions.projectRoot)}dist/${normalizedOptions.projectRoot} main.go`,
           cwd: normalizedOptions.projectRoot
         }
       },

--- a/packages/nx-go/src/generators/library/files/index.ts__template__
+++ b/packages/nx-go/src/generators/library/files/index.ts__template__
@@ -1,1 +1,0 @@
-const variable = "<%= projectName %>";

--- a/packages/nx-go/src/generators/library/generator.ts
+++ b/packages/nx-go/src/generators/library/generator.ts
@@ -52,7 +52,7 @@ export default async function (tree: Tree, options: LibraryGeneratorSchema) {
   addProjectConfiguration(tree, normalizedOptions.projectName, {
     root: normalizedOptions.projectRoot,
     projectType: 'library',
-    sourceRoot: `${normalizedOptions.projectRoot}/src`,
+    sourceRoot: normalizedOptions.projectRoot,
     targets: {
       lint: {
         executor: '@nrwl/workspace:run-commands',

--- a/packages/nx-go/src/generators/library/generator.ts
+++ b/packages/nx-go/src/generators/library/generator.ts
@@ -46,21 +46,6 @@ function normalizeOptions(
   };
 }
 
-function addFiles(tree: Tree, options: NormalizedSchema) {
-  const templateOptions = {
-    ...options,
-    ...names(options.name),
-    offsetFromRoot: offsetFromRoot(options.projectRoot),
-    template: '',
-  };
-  generateFiles(
-    tree,
-    path.join(__dirname, 'files'),
-    options.projectRoot,
-    templateOptions
-  );
-}
-
 export default async function (tree: Tree, options: LibraryGeneratorSchema) {
   const normalizedOptions = normalizeOptions(tree, options);
 
@@ -87,6 +72,5 @@ export default async function (tree: Tree, options: LibraryGeneratorSchema) {
     tags: normalizedOptions.parsedTags,
   });
 
-  addFiles(tree, normalizedOptions);
   await formatFiles(tree);
 }


### PR DESCRIPTION
- ライブラリの生成時にindex.tsを作らないようにした
- 生成したapp/libのproject.jsonのsourceRootに/srcを付けない
- 生成したappのbuildタスクの出力場所に余分な"/"を付けないようにした